### PR TITLE
Enhancement to configure doctypes which can be ignored and bug fix

### DIFF
--- a/frappe_s3_attachment/controller.py
+++ b/frappe_s3_attachment/controller.py
@@ -179,7 +179,8 @@ def file_upload_to_s3(doc, method):
     site_path = frappe.utils.get_site_path()
     parent_doctype = doc.attached_to_doctype
     parent_name = doc.attached_to_name
-    if parent_doctype != "Data Import":
+    ignore_s3_upload_for_doctype = frappe.local.conf.get('ignore_s3_upload_for_doctype') or ['Data Import']
+    if parent_doctype not in ignore_s3_upload_for_doctype:
         if not doc.is_private:
             file_path = site_path + '/public' + path
         else:
@@ -201,6 +202,10 @@ def file_upload_to_s3(doc, method):
         doc = frappe.db.sql("""UPDATE `tabFile` SET file_url=%s, folder=%s,
             old_parent=%s, content_hash=%s WHERE name=%s""", (
             file_url, 'Home/Attachments', 'Home/Attachments', key, doc.name))
+
+        if frappe.get_meta(parent_doctype).get('image_field'):
+            frappe.db.set_value(parent_doctype, parent_name, frappe.get_meta(parent_doctype).get('image_field'), file_url)
+
         frappe.db.commit()
 
 


### PR DESCRIPTION
added code to have configurable doctypes which can be ignored this can be done by configuring it in site config 
"ignore_s3_upload_for_doctype": ["Data Import", "Prepared Report"]

and also if there is a image_field set in doctype then update that