### PR TITLE
fix: Reload File document after S3 Upload

### DIFF
--- a/frappe_s3_attachment/controller.py
+++ b/frappe_s3_attachment/controller.py
@@ -228,14 +228,12 @@ def file_upload_to_s3(doc, method):
                 key
             )
         os.remove(file_path)
-        doc = frappe.db.sql("""UPDATE `tabFile` SET file_url=%s, folder=%s,
+        frappe.db.sql("""UPDATE `tabFile` SET file_url=%s, folder=%s,
             old_parent=%s, content_hash=%s WHERE name=%s""", (
             file_url, 'Home/Attachments', 'Home/Attachments', key, doc.name))
 
-        if frappe.get_meta(parent_doctype).get('image_field'):
-            frappe.db.set_value(parent_doctype, parent_name, frappe.get_meta(parent_doctype).get('image_field'), file_url)
-
         frappe.db.commit()
+        doc.reload()
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Two issues are being fixed here:
- Not all File uploads are `image_field` uploads. If a File was uploaded on a Doctype with `image_field` specified, that do not mean that File was uploaded for the `image_field`
- Reload the File document before returning so that frappe-js sets the correct file_urls in `Attach` & `Attach Image` fields