### PR TITLE
Added 'File' as default value in place of an empty 'parent_doctype'

### DIFF
--- a/frappe_s3_attachment/controller.py
+++ b/frappe_s3_attachment/controller.py
@@ -205,7 +205,7 @@ def file_upload_to_s3(doc, method):
     s3_upload = S3Operations()
     path = doc.file_url
     site_path = frappe.utils.get_site_path()
-    parent_doctype = doc.get("attached_to_doctype", "File")
+    parent_doctype = doc.attached_to_doctype or 'File'
     parent_name = doc.attached_to_name
     ignore_s3_upload_for_doctype = frappe.local.conf.get('ignore_s3_upload_for_doctype') or ['Data Import']
     if parent_doctype not in ignore_s3_upload_for_doctype:

--- a/frappe_s3_attachment/controller.py
+++ b/frappe_s3_attachment/controller.py
@@ -87,6 +87,8 @@ class S3Operations(object):
 
         doc_path = None
 
+        parent_doctype = parent_doctype if parent_doctype else "media"
+
         if not doc_path:
             if self.folder_name:
                 final_key = self.folder_name + "/" + year + "/" + month + \

--- a/frappe_s3_attachment/controller.py
+++ b/frappe_s3_attachment/controller.py
@@ -87,7 +87,7 @@ class S3Operations(object):
 
         doc_path = None
 
-        parent_doctype = parent_doctype if parent_doctype else "media"
+        parent_doctype = parent_doctype if parent_doctype else "File"
 
         if not doc_path:
             if self.folder_name:

--- a/frappe_s3_attachment/controller.py
+++ b/frappe_s3_attachment/controller.py
@@ -87,8 +87,6 @@ class S3Operations(object):
 
         doc_path = None
 
-        parent_doctype = parent_doctype if parent_doctype else "File"
-
         if not doc_path:
             if self.folder_name:
                 final_key = self.folder_name + "/" + year + "/" + month + \
@@ -207,7 +205,7 @@ def file_upload_to_s3(doc, method):
     s3_upload = S3Operations()
     path = doc.file_url
     site_path = frappe.utils.get_site_path()
-    parent_doctype = doc.attached_to_doctype
+    parent_doctype = doc.get("attached_to_doctype", "File")
     parent_name = doc.attached_to_name
     ignore_s3_upload_for_doctype = frappe.local.conf.get('ignore_s3_upload_for_doctype') or ['Data Import']
     if parent_doctype not in ignore_s3_upload_for_doctype:


### PR DESCRIPTION
When uploading a file, say in a custom dialog. The `parent_doctype` variable will be empty (`None`) so when the controller tries to concatenate the filepath, it throws an error.

This change will use `File` as a default value in that case.