### PR TITLE
fix: boto3 version not compatible with python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-boto3==1.4.7
+boto3==1.24.13
 botocore==1.7.48
 python-magic==0.4.18


### PR DESCRIPTION
```
In [1]: import boto3
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
Cell In[1], line 1
----> 1 import boto3

File ~/frappe-bench/env/lib/python3.11/site-packages/boto3/__init__.py:16
      1 # Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
      2 #
      3 # Licensed under the Apache License, Version 2.0 (the "License"). You
   (...)
     11 # ANY KIND, either express or implied. See the License for the specific
     12 # language governing permissions and limitations under the License.
     14 import logging
---> 16 from boto3.session import Session
     19 __author__ = 'Amazon Web Services'
     20 __version__ = '1.4.7'

File ~/frappe-bench/env/lib/python3.11/site-packages/boto3/session.py:17
     14 import copy
     15 import os
---> 17 import botocore.session
     18 from botocore.client import Config
     19 from botocore.exceptions import DataNotFoundError, UnknownServiceError

File ~/frappe-bench/env/lib/python3.11/site-packages/botocore/session.py:25
     22 import platform
     24 from botocore import __version__
---> 25 import botocore.configloader
     26 import botocore.credentials
     27 import botocore.client

File ~/frappe-bench/env/lib/python3.11/site-packages/botocore/configloader.py:19
     16 import copy
     17 import sys
---> 19 from botocore.compat import six
     21 import botocore.exceptions
     24 def multi_file_load_config(*filenames):

File ~/frappe-bench/env/lib/python3.11/site-packages/botocore/compat.py:23
     20 import logging
     22 from botocore.vendored import six
---> 23 from botocore.exceptions import MD5UnavailableError
     24 from botocore.vendored.requests.packages.urllib3 import exceptions
     26 logger = logging.getLogger(__name__)

File ~/frappe-bench/env/lib/python3.11/site-packages/botocore/exceptions.py:15
      1 # Copyright (c) 2012-2013 Mitch Garnaat http://garnaat.org/
      2 # Copyright 2012-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
      3 #
   (...)
     12 # ANY KIND, either express or implied. See the License for the specific
     13 # language governing permissions and limitations under the License.
     14 from __future__ import unicode_literals
---> 15 from botocore.vendored.requests.exceptions import ConnectionError
     18 class BotoCoreError(Exception):
     19     """
     20     The base exception class for BotoCore exceptions.
     21
     22     :ivar msg: The descriptive message associated with the error.
     23     """

File ~/frappe-bench/env/lib/python3.11/site-packages/botocore/vendored/requests/__init__.py:58
     55 except ImportError:
     56     pass
---> 58 from . import utils
     59 from .models import Request, Response, PreparedRequest
     60 from .api import request, get, head, post, patch, put, delete, options

File ~/frappe-bench/env/lib/python3.11/site-packages/botocore/vendored/requests/utils.py:26
     24 from . import __version__
     25 from . import certs
---> 26 from .compat import parse_http_list as _parse_list_header
     27 from .compat import (quote, urlparse, bytes, str, OrderedDict, unquote, is_py2,
     28                      builtin_str, getproxies, proxy_bypass, urlunparse,
     29                      basestring)
     30 from .cookies import RequestsCookieJar, cookiejar_from_dict

File ~/frappe-bench/env/lib/python3.11/site-packages/botocore/vendored/requests/compat.py:7
      1 # -*- coding: utf-8 -*-
      3 """
      4 pythoncompat
      5 """
----> 7 from .packages import chardet
      9 import sys
     11 # -------
     12 # Pythons
     13 # -------
     14
     15 # Syntax sugar.

File ~/frappe-bench/env/lib/python3.11/site-packages/botocore/vendored/requests/packages/__init__.py:3
      1 from __future__ import absolute_import
----> 3 from . import urllib3

File ~/frappe-bench/env/lib/python3.11/site-packages/botocore/vendored/requests/packages/urllib3/__init__.py:10
      6 __license__ = 'MIT'
      7 __version__ = '1.10.4'
---> 10 from .connectionpool import (
     11     HTTPConnectionPool,
     12     HTTPSConnectionPool,
     13     connection_from_url
     14 )
     16 from . import exceptions
     17 from .filepost import encode_multipart_formdata

File ~/frappe-bench/env/lib/python3.11/site-packages/botocore/vendored/requests/packages/urllib3/connectionpool.py:38
     31 from .connection import (
     32     port_by_scheme,
     33     DummyConnection,
     34     HTTPConnection, HTTPSConnection, VerifiedHTTPSConnection,
     35     HTTPException, BaseSSLError, ConnectionError
     36 )
     37 from .request import RequestMethods
---> 38 from .response import HTTPResponse
     40 from .util.connection import is_connection_dropped
     41 from .util.retry import Retry

File ~/frappe-bench/env/lib/python3.11/site-packages/botocore/vendored/requests/packages/urllib3/response.py:9
      6 import io
      7 from socket import timeout as SocketTimeout
----> 9 from ._collections import HTTPHeaderDict
     10 from .exceptions import (
     11     ProtocolError, DecodeError, ReadTimeoutError, ResponseNotChunked
     12 )
     13 from .packages.six import string_types as basestring, binary_type, PY3

File ~/frappe-bench/env/lib/python3.11/site-packages/botocore/vendored/requests/packages/urllib3/_collections.py:1
----> 1 from collections import Mapping, MutableMapping
      2 try:
      3     from threading import RLock

ImportError: cannot import name 'Mapping' from 'collections' (/usr/lib/python3.11/collections/__init__.py)
```