### PR TITLE
Add boto3 to project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,5 @@ frappe = ">=10.0.0,<17.0.0"
 
 dependencies = [
 	"python-magic==0.4.18",
+    "boto3"
 ]


### PR DESCRIPTION
To fix in v16
  File "<frozen importlib._bootstrap>", line 491, in _call_with_frames_removed
  File "apps/frappe_s3_attachment/frappe_s3_attachment/controller.py", line 9, in <module>
    import boto3
ModuleNotFoundError: No module named 'boto3'