### PR TITLE
Add AWS SDK dependencies for boto3 and botocore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,9 @@ frappe = ">=10.0.0,<17.0.0"
 
 dependencies = [
 	"python-magic==0.4.18",
+    "boto3>=1.34.0",
+    "botocore>=1.34.0",
+    "s3transfer>=0.10.0",
+    "six>=1.16.0",
+    "urllib3<2.0.0"
 ]


### PR DESCRIPTION
To fix in v16
File "", line 491, in _call_with_frames_removed
File "apps/frappe_s3_attachment/frappe_s3_attachment/controller.py", line 9, in
import boto3
ModuleNotFoundError: No module named 'boto3'