### PR TITLE
fix: URL-encode file_name in S3 metadata to support non-ASCII filenames

### DIFF
--- a/frappe_s3_attachment/controller.py
+++ b/frappe_s3_attachment/controller.py
@@ -5,6 +5,7 @@ import os
 import random
 import re
 import string
+from urllib.parse import quote
 
 import boto3
 
@@ -118,7 +119,7 @@ class S3Operations(object):
                         "ContentType": content_type,
                         "Metadata": {
                             "ContentType": content_type,
-                            "file_name": file_name
+                            "file_name": quote(file_name, safe="")
                         }
                     }
                 )


### PR DESCRIPTION
Title: fix: URL-encode file_name in S3 metadata to support non-ASCII filenames, 
Issue Link: https://github.com/zerodha/frappe-attachments-s3/issues/92

  Body:                                                                                                                      
   
  ## Summary                                                                                                                 
                                                            
  - Fixes S3 upload failure when filenames contain non-ASCII characters (e.g., Chinese, Japanese, Korean)
  - The error `S3 metadata can only contain ASCII characters` occurs because `file_name` is passed directly into S3 metadata,
   which only supports ASCII
  - URL-encodes the `file_name` value using `urllib.parse.quote` before storing it in S3 metadata

  ## Root Cause

  S3 object metadata values must be ASCII-only. When a file with a non-ASCII filename (e.g., `报告.pdf`) is uploaded, the raw
   filename is set in `ExtraArgs["Metadata"]["file_name"]`, causing boto3 to reject the upload.

  ## Changes

  - **`frappe_s3_attachment/controller.py`**: Added `from urllib.parse import quote` and wrapped `file_name` with
  `quote(file_name, safe="")` in the S3 upload metadata (private file uploads). Public uploads were already unaffected as
  they don't include `file_name` in metadata.

  ## Test Plan

  - [ ] Upload a file with ASCII filename — should work as before
  - [ ] Upload a file with non-ASCII filename (e.g., Chinese characters like `测试文件.pdf`) — should no longer fail with
  metadata error
  - [ ] Verify the file is accessible and downloadable after upload