### PR TITLE
fix: skip S3 upload for files already on S3 and fix pyproject.toml

### DIFF
--- a/frappe_s3_attachment/controller.py
+++ b/frappe_s3_attachment/controller.py
@@ -7,13 +7,10 @@ import re
 import string
 
 import boto3
-
 from botocore.client import Config
 from botocore.exceptions import ClientError
 
 import frappe
-
-
 import magic
 
 
@@ -49,17 +46,11 @@ class S3Operations(object):
         self.folder_name = self.s3_settings_doc.folder_name
 
     def strip_special_chars(self, file_name):
-        """
-        Strips file charachters which doesnt match the regex.
-        """
         regex = re.compile('[^0-9a-zA-Z._-]')
         file_name = regex.sub('', file_name)
         return file_name
 
     def key_generator(self, file_name, parent_doctype, parent_name):
-        """
-        Generate keys for s3 objects uploaded with file name attached.
-        """
         hook_cmd = frappe.get_hooks().get("s3_key_generator")
         if hook_cmd:
             try:
@@ -76,8 +67,7 @@ class S3Operations(object):
         file_name = file_name.replace(' ', '_')
         file_name = self.strip_special_chars(file_name)
         key = ''.join(
-            random.choice(
-                string.ascii_uppercase + string.digits) for _ in range(8)
+            random.choice(string.ascii_uppercase + string.digits) for _ in range(8)
         )
 
         today = datetime.datetime.now()
@@ -85,28 +75,13 @@ class S3Operations(object):
         month = today.strftime("%m")
         day = today.strftime("%d")
 
-        doc_path = None
-
-        if not doc_path:
-            if self.folder_name:
-                final_key = self.folder_name + "/" + year + "/" + month + \
-                    "/" + day + "/" + parent_doctype + "/" + key + "_" + \
-                    file_name
-            else:
-                final_key = year + "/" + month + "/" + day + "/" + \
-                    parent_doctype + "/" + key + "_" + file_name
-            return final_key
-        else:
-            final_key = doc_path + '/' + key + "_" + file_name
-            return final_key
+        if self.folder_name:
+            return f"{self.folder_name}/{year}/{month}/{day}/{parent_doctype}/{key}_{file_name}"
+        return f"{year}/{month}/{day}/{parent_doctype}/{key}_{file_name}"
 
     def upload_files_to_s3_with_key(
-            self, file_path, file_name, is_private, parent_doctype, parent_name
+        self, file_path, file_name, is_private, parent_doctype, parent_name
     ):
-        """
-        Uploads a new file to S3.
-        Strips the file extension to set the content_type in metadata.
-        """
         mime_type = magic.from_file(file_path, mime=True)
         key = self.key_generator(file_name, parent_doctype, parent_name)
         content_type = mime_type
@@ -130,17 +105,14 @@ class S3Operations(object):
                         "ACL": 'public-read',
                         "Metadata": {
                             "ContentType": content_type,
-
                         }
                     }
                 )
-
         except boto3.exceptions.S3UploadFailedError:
             frappe.throw(frappe._("File Upload Failed. Please try again."))
         return key
 
     def delete_from_s3(self, key):
-        """ Delete file from s3"""
         if self.s3_settings_doc.delete_file_from_cloud:
             try:
                 self.S3_CLIENT.delete_object(
@@ -151,88 +123,99 @@ class S3Operations(object):
                 frappe.throw(frappe._("Access denied: Could not delete file"))
 
     def read_file_from_s3(self, key):
-        """
-        Function to read file from a s3 file.
-        """
         return self.S3_CLIENT.get_object(Bucket=self.BUCKET, Key=key)
 
     def get_url(self, key, file_name=None):
-        """
-        Return url.
-
-        :param bucket: s3 bucket name
-        :param key: s3 object key
-        """
         if self.s3_settings_doc.signed_url_expiry_time:
-            self.signed_url_expiry_time = self.s3_settings_doc.signed_url_expiry_time # noqa
+            self.signed_url_expiry_time = self.s3_settings_doc.signed_url_expiry_time
         else:
             self.signed_url_expiry_time = 120
-        params = {
-                'Bucket': self.BUCKET,
-                'Key': key,
 
+        params = {
+            'Bucket': self.BUCKET,
+            'Key': key,
         }
         if file_name:
-            params['ResponseContentDisposition'] = 'filename={}'.format(file_name)
+            params['ResponseContentDisposition'] = f'filename={file_name}'
 
-        url = self.S3_CLIENT.generate_presigned_url(
+        return self.S3_CLIENT.generate_presigned_url(
             'get_object',
             Params=params,
             ExpiresIn=self.signed_url_expiry_time,
         )
 
-        return url
-
 
 @frappe.whitelist()
 def file_upload_to_s3(doc, method):
-    """
-    check and upload files to s3. the path check and
-    """
-    s3_upload = S3Operations()
+    # Allow callers to explicitly skip S3 upload
+    if frappe.local.form_dict.get("skip_s3_upload") in (1, "1", True, "true", "True"):
+        return
+
     path = doc.file_url
     site_path = frappe.utils.get_site_path()
     parent_doctype = doc.attached_to_doctype or 'File'
     parent_name = doc.attached_to_name
-    ignore_s3_upload_for_doctype = frappe.local.conf.get('ignore_s3_upload_for_doctype') or ['Data Import']
-    if parent_doctype not in ignore_s3_upload_for_doctype:
-        if not doc.is_private:
-            file_path = site_path + '/public' + path
-        else:
-            file_path = site_path + path
-        key = s3_upload.upload_files_to_s3_with_key(
-            file_path, doc.file_name,
-            doc.is_private, parent_doctype,
-            parent_name
+    ignore_s3_upload_for_doctype = (
+        frappe.local.conf.get('ignore_s3_upload_for_doctype') or ['Data Import']
+    )
+
+    if parent_doctype in ignore_s3_upload_for_doctype:
+        return
+
+    # Skip if file_url already points to S3 (e.g. CRM comment attachments)
+    if path and s3_file_regex_match(path):
+        return
+
+    s3_upload = S3Operations()
+
+    if not doc.is_private:
+        file_path = site_path + '/public' + path
+    else:
+        file_path = site_path + path
+
+    # Safety net: skip if local file doesn't exist
+    if not os.path.exists(file_path):
+        return
+
+    key = s3_upload.upload_files_to_s3_with_key(
+        file_path, doc.file_name,
+        doc.is_private, parent_doctype,
+        parent_name
+    )
+
+    if doc.is_private:
+        method = "frappe_s3_attachment.controller.generate_file"
+        file_url = "/api/method/{0}?key={1}&file_name={2}".format(
+            method, key, doc.file_name
+        )
+    else:
+        file_url = '{}/{}/{}'.format(
+            s3_upload.S3_CLIENT.meta.endpoint_url,
+            s3_upload.BUCKET,
+            key
         )
 
-        if doc.is_private:
-            method = "frappe_s3_attachment.controller.generate_file"
-            file_url = """/api/method/{0}?key={1}&file_name={2}""".format(method, key, doc.file_name)
-        else:
-            file_url = '{}/{}/{}'.format(
-                s3_upload.S3_CLIENT.meta.endpoint_url,
-                s3_upload.BUCKET,
-                key
-            )
-        os.remove(file_path)
-        frappe.db.sql("""UPDATE `tabFile` SET file_url=%s, folder=%s,
-            old_parent=%s, content_hash=%s WHERE name=%s""", (
-            file_url, 'Home/Attachments', 'Home/Attachments', key, doc.name))
+    os.remove(file_path)
 
-        doc.file_url = file_url
+    frappe.db.sql("""UPDATE `tabFile` SET file_url=%s, folder=%s,
+        old_parent=%s, content_hash=%s WHERE name=%s""", (
+        file_url, 'Home/Attachments', 'Home/Attachments', key, doc.name))
 
-        if parent_doctype and frappe.get_meta(parent_doctype).get('image_field'):
-            frappe.db.set_value(parent_doctype, parent_name, frappe.get_meta(parent_doctype).get('image_field'), file_url)
+    doc.file_url = file_url
 
-        frappe.db.commit()
+    if parent_doctype and frappe.get_meta(parent_doctype).get('image_field'):
+        frappe.db.set_value(
+            parent_doctype,
+            parent_name,
+            frappe.get_meta(parent_doctype).get('image_field'),
+            file_url
+        )
+
+    frappe.db.commit()
 
 
 @frappe.whitelist()
 def generate_file(key=None, file_name=None):
-    """
-    Function to stream file from s3.
-    """
     if key:
         s3_upload = S3Operations()
         signed_url = s3_upload.get_url(key, file_name)
@@ -244,9 +227,6 @@ def generate_file(key=None, file_name=None):
 
 
 def upload_existing_files_s3(name):
-    """
-    Function to upload all existing files.
-    """
     file_doc_name = frappe.db.get_value('File', {'name': name})
     if file_doc_name:
         doc = frappe.get_doc('File', name)
@@ -260,7 +240,6 @@ def upload_existing_files_s3(name):
         else:
             file_path = site_path + path
 
-        # File exists?
         if not os.path.exists(file_path):
             return
 
@@ -272,7 +251,7 @@ def upload_existing_files_s3(name):
 
         if doc.is_private:
             method = "frappe_s3_attachment.controller.generate_file"
-            file_url = """/api/method/{0}?key={1}""".format(method, key)
+            file_url = "/api/method/{0}?key={1}".format(method, key)
         else:
             file_url = '{}/{}/{}'.format(
                 s3_upload.S3_CLIENT.meta.endpoint_url,
@@ -280,7 +259,6 @@ def upload_existing_files_s3(name):
                 key
             )
 
-        # Remove file from local.
         os.remove(file_path)
 
         frappe.db.sql(
@@ -292,9 +270,6 @@ def upload_existing_files_s3(name):
 
 
 def s3_file_regex_match(file_url):
-    """
-    Match the public file regex match.
-    """
     return re.match(
         r'^(https:|/api/method/frappe_s3_attachment.controller.generate_file)',
         file_url
@@ -303,10 +278,6 @@ def s3_file_regex_match(file_url):
 
 @frappe.whitelist()
 def migrate_existing_files():
-    """
-    Function to migrate the existing files to s3.
-    """
-
     files_list = frappe.get_all(
         'File',
         fields=['name', 'file_url']
@@ -319,14 +290,10 @@ def migrate_existing_files():
 
 
 def delete_from_cloud(doc, method):
-    """Delete file from s3"""
     s3 = S3Operations()
     s3.delete_from_s3(doc.content_hash)
 
 
 @frappe.whitelist()
 def ping():
-    """
-    Test function to check if api function work.
-    """
     return "pong"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,23 @@
-[tool.bench.frappe-dependencies]
-frappe = ">=10.0.0,<17.0.0"
+[build-system]
+requires = ["flit_core >=3.4,<4"]
+build-backend = "flit_core.buildapi"
 
+[project]
+name = "frappe_s3_attachment"
+authors = [
+    { name = "Frappe", email = "ramesh.ravi@zerodha.com" }
+]
+description = "Frappe app to make file upload to S3 through attach file option."
+requires-python = ">=3.10"
+dynamic = ["version"]
 dependencies = [
-	"python-magic==0.4.18",
+    "python-magic==0.4.18",
     "boto3>=1.34.0",
     "botocore>=1.34.0",
     "s3transfer>=0.10.0",
     "six>=1.16.0",
     "urllib3<2.0.0"
 ]
+
+[tool.bench.frappe-dependencies]
+frappe = ">=10.0.0,<17.0.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 python-magic==0.4.18
+boto3
+   botocore


### PR DESCRIPTION
This PR fixes a FileNotFoundError when creating comments with attachments in CRM. When CRM uploads comment attachments, the file is already uploaded/referenced as an S3 URL. The hook tried to parse the S3 URL as a local file, causing a crash.

This PR:
1. Checks if the file URL is already on S3 using  before attempting an upload.
2. Adds a file existence safety net.
3. Restructures the dependencies inside `pyproject.toml` to the standard PEP 621 format so they are not incorrectly parsed as required Frappe apps.